### PR TITLE
Changed the way of importing features

### DIFF
--- a/aop/extensions/__init__.py
+++ b/aop/extensions/__init__.py
@@ -1,3 +1,11 @@
-import aop.extensions.highlight
-import aop.extensions.linenumbers
-import aop.extensions.functionclick
+from importlib import import_module
+
+possible_features = ['aop.extensions.highlight',
+                     'aop.extensions.linenumbers',
+                     'aop.extensions.functionclick']
+
+for feature in possible_features:
+    try:
+        import_module(feature)
+    except ImportError:
+        pass


### PR DESCRIPTION
In the old way of importing, the program would fail if we would really strip out some features. For example, if all highlighing related files are removed, the static files would not pose a problem, but if `highlight.py` was removed, the import of `aop.extensions.highlight` fails.