### PR TITLE
Added check for aop errors

### DIFF
--- a/aop/__init__.py
+++ b/aop/__init__.py
@@ -1,4 +1,4 @@
-from aop.aop import extends, extensible
+from aop.aop import extends, extensible, check_errors
 from dotenv import load_dotenv
 
 load_dotenv()

--- a/editor/app.py
+++ b/editor/app.py
@@ -2,11 +2,12 @@ from flask import Flask, render_template, request, redirect
 from flask_bootstrap import Bootstrap
 import os
 import aop
-from aop import extensible
+from aop import extensible, check_errors
 
 
 app = Flask("Notepad--", root_path=os.path.join(os.getcwd(), 'editor'))
 Bootstrap(app)
+
 
 @extensible
 def define_endpoints(flaskapp):
@@ -56,3 +57,6 @@ def feature_page_htmls(htmls):
 
 
 define_endpoints(app)
+
+# check aop errors
+check_errors()


### PR DESCRIPTION
Previously, you were able to define a function that extends a non-existing function. Not that it really gave any problems, but debugging related problems was a bit more challenging because of this. 